### PR TITLE
add shebang for builded bin

### DIFF
--- a/src/Commands/Builder.php
+++ b/src/Commands/Builder.php
@@ -116,7 +116,7 @@ class Builder extends AbstractCommand
             ->getCompiler($name);
 
         $compiler->buildFromDirectory(BASE_PATH, '#'.implode('|', $this->structure).'#');
-        $compiler->setStub($compiler->createDefaultStub('bootstrap/init.php'));
+        $compiler->setStub("#!/usr/bin/env php \n" . $compiler->createDefaultStub('bootstrap/init.php'));
 
         return $this;
     }

--- a/src/Commands/Builder.php
+++ b/src/Commands/Builder.php
@@ -116,7 +116,7 @@ class Builder extends AbstractCommand
             ->getCompiler($name);
 
         $compiler->buildFromDirectory(BASE_PATH, '#'.implode('|', $this->structure).'#');
-        $compiler->setStub("#!/usr/bin/env php \n" . $compiler->createDefaultStub('bootstrap/init.php'));
+        $compiler->setStub("#!/usr/bin/env php \n".$compiler->createDefaultStub('bootstrap/init.php'));
 
         return $this;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

add shebang to .phar file

```
#!/usr/bin/env php
```

## Motivation and context

without the shebang, it will be executed as shell script

```
❯ ./builds/application
./builds/application: line 1: ?php: No such file or directory
./builds/application: line 3: =: command not found
./builds/application: line 5: syntax error near unexpected token `'phar','
./builds/application: line 5: `if (in_array('phar', stream_get_wrappers()) && class_exists('Phar', 0)) {'
```