### PR TITLE
Fix standalone phar permissions

### DIFF
--- a/src/Commands/Builder.php
+++ b/src/Commands/Builder.php
@@ -96,7 +96,8 @@ class Builder extends AbstractCommand
     {
         $this->comment("Building: $name");
         $this->compile($name)
-            ->cleanUp($name);
+            ->cleanUp($name)
+            ->setPermissions($name);
 
         $this->info("Standalone application compiled into: builds/$name");
 
@@ -168,6 +169,20 @@ class Builder extends AbstractCommand
         $file = self::BUILD_PATH."/$name";
         rename("$file.phar", $file);
 
+        return $this;
+    }
+
+    /**
+     * Sets the executable mode on the standalone application file.
+     *
+     * @param string $name
+     *
+     * @return $this
+     */
+    protected function setPermissions($name): Builder
+    {
+        $file = self::BUILD_PATH."/$name";
+        chmod($file, 0755);
         return $this;
     }
 }

--- a/src/Commands/Builder.php
+++ b/src/Commands/Builder.php
@@ -183,6 +183,7 @@ class Builder extends AbstractCommand
     {
         $file = self::BUILD_PATH."/$name";
         chmod($file, 0755);
+
         return $this;
     }
 }


### PR DESCRIPTION
Sets the executable bit on the compiled standalone phar

## Description

This adds the automatic permission change on the final builds/application file to set 0755 permissions (executable by everyone).

## Motivation and context

The pull request https://github.com/nunomaduro/zero-framework/pull/2 adds the possibility to call the application directly ("./builds/application" instead of "php builds/application") but it must be manually made executable before one can do this. This change automates the task.

## How has this been tested?

It was tested manually to catch regressions on Linux and Windows (no MacOS tests were made)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)

## Checklist:

- [ x ] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [ x ] My pull request addresses exactly one patch/feature.
- [ x ] I have created a branch for this patch/feature.
- [ x ] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.

Note: I will create a separate pull request for a related documentation update on the laravel-zero repository.
